### PR TITLE
Spin until vm tools are recognized

### DIFF
--- a/post-processor.go
+++ b/post-processor.go
@@ -326,6 +326,7 @@ func doUpload(ui packer.Ui, url string, file string) error {
 	bar.ShowSpeed = true
 	bar.Callback = ui.Message
 	bar.RefreshRate = time.Second * 5
+	bar.SetWidth(40)
 	reader := bar.NewProxyReader(data)
 
 	req, err := http.NewRequest("PUT", url, reader)


### PR DESCRIPTION
Ran into a problem where the vm tools weren't recognized on the template clone. I'm not sure if it was done before the sleep or not. But when I did it manually, it took almost 3 minutes. So maybe making this a little more resilient will help. 
