### PR TITLE
Fix incorrect locations for packer artifacts

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/hashicorp/packer/packer/plugin"
 )
 
 func main() {

--- a/post-processor.go
+++ b/post-processor.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/cheggaaa/pb"
-	vmwarecommon "github.com/mitchellh/packer/builder/vmware/common"
-	"github.com/mitchellh/packer/common"
-	"github.com/mitchellh/packer/helper/config"
-	"github.com/mitchellh/packer/packer"
-	"github.com/mitchellh/packer/template/interpolate"
+	vmwarecommon "github.com/hashicorp/packer/builder/vmware/common"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vim25/types"
@@ -24,8 +24,8 @@ import (
 )
 
 var builtins = map[string]string{
-	"mitchellh.virtualbox": "virtualbox",
-	"mitchellh.vmware":     "vmware",
+	"hashicorp.virtualbox": "virtualbox",
+	"hashicorp.vmware":     "vmware",
 }
 
 type Config struct {


### PR DESCRIPTION
Replace places where mitchellh was set with hashicorp.

Now it builds OK. 

Prior to this I was getting
```
Digest: sha256:f0b5dab7581eddb49dabd1d1b9aa505ca3edcdf79a66395b5bfa4f3c036b49ef
Status: Downloaded newer image for golang:1.8
 ---> 0d283eb41a92
Step 2/2 : RUN go get github.com/Banno/packer-post-processor-vsphere-ova
 ---> Running in 9a33cf8a1342
# github.com/mitchellh/packer/builder/vmware/common
src/github.com/mitchellh/packer/builder/vmware/common/ssh.go:43: cannot use "github.com/hashicorp/packer/communicator/ssh".PasswordKeyboardInteractive(config.Comm.SSHPassword) (type "github.com/hashicorp/packer/vendor/golang.org/x/crypto/ssh".KeyboardInteractiveChallenge) as type "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".KeyboardInteractiveChallenge in argument to "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".KeyboardInteractive
src/github.com/mitchellh/packer/builder/vmware/common/ssh.go:52: cannot use signer (type "github.com/hashicorp/packer/vendor/golang.org/x/crypto/ssh".Signer) as type "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".Signer in argument to "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".PublicKeys:
    "github.com/hashicorp/packer/vendor/golang.org/x/crypto/ssh".Signer does not implement "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".Signer (wrong type for PublicKey method)
        have PublicKey() "github.com/hashicorp/packer/vendor/golang.org/x/crypto/ssh".PublicKey
        want PublicKey() "github.com/mitchellh/packer/vendor/golang.org/x/crypto/ssh".PublicKey
The command '/bin/sh -c go get github.com/Banno/packer-post-processor-vsphere-ova' returned a non-zero code: 2
```